### PR TITLE
Fix example template. Update Readme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 target/
 example/apply.rety
 example/roles
+example/sonar-auth-openshift-plugin-*.jar
 .project
 .classpath
 .vscode

--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 ## Description
 
-This plugin enables user authentication and Single Sign-On via OpenShift. It is heavily based on the code by Julien Lancelot. Tested on version 7 of Sonarqube and OCP 3.11. Intended to run deployed in a pod on OpenShift.
+This plugin enables user authentication and Single Sign-On via OpenShift. It is heavily based on the code by Julien Lancelot. Tested on version 7 of Sonarqube and OCP 3.11. It is intended to run deployed in a pod on OpenShift.
 
 This plugin is designed to work out of the box without configuration. During plugin deployment, it looks up oauth information from OpenShift's well-known information and takes advantage of information already on the running pod. 
 
 During deployment the plugin will:
 
-- Look like well-known oauth information at https://openshift.default.svc
+- Look up well-known oauth information at https://openshift.default.svc
 - Pull the service account client_id, secret and cert from the file system 
 - Pull the OpenShift API location from the env variables of the pod
 - Get the ServiceAccount name from the API

--- a/example/README.md
+++ b/example/README.md
@@ -2,7 +2,7 @@
 
 
 ```
-Instructions use ansible. Windows users use a vm or apply each command manually
+This example uses ansible. Windows users use a vm or apply each command manually
 ```
 
 This section contains an example for how this plugin can be used with Sonarqube

--- a/example/templates/sonarqube-deploy.yml
+++ b/example/templates/sonarqube-deploy.yml
@@ -18,16 +18,6 @@ objects:
   subjects:
   - kind: ServiceAccount
     name: sonarqube
-  userNames:
-  - system:serviceaccount:sonarqube:sonarqube
-- apiVersion: v1
-  kind: Secret
-  stringData:
-    password: ${SONAR_LDAP_BIND_PASSWORD}
-    username: ${SONAR_LDAP_BIND_DN}
-  metadata:
-    name: sonar-ldap-bind-dn
-  type: kubernetes.io/basic-auth
 - apiVersion: v1
   kind: PersistentVolumeClaim
   metadata:
@@ -214,46 +204,6 @@ parameters:
   - name: PROXY_PASSWORD
     description: Password credential when the Proxy Server requires authentication
     displayName: Proxy server password
-  - name: SONAR_LDAP_BIND_DN
-    description: When using LDAP authentication, this is the Distinguished Name used for binding to the LDAP server
-    displayName: LDAP Bind DN
-  - name: SONAR_LDAP_BIND_PASSWORD
-    description: When using LDAP for authentication, this is the password with which to bind to the LDAP server
-    displayName: LDAP Bind Password
-  - name: SONAR_LDAP_URL
-    description: When using LDAP for authentication, this is the URL of the LDAP server in the form of ldap(s)://<hostname>:<port>
-    displayName: LDAP Server URL
-  - name: SONAR_LDAP_REALM
-    description: When using LDAP, this allows for specifying a Realm within the directory server (Usually not used)
-    displayName: LDAP Realm
-  - name: SONAR_LDAP_AUTHENTICATION
-    description: When using LDAP, this is the bind method (simple, GSSAPI, kerberos, CRAM-MD5, DIGEST-MD5)
-    displayName: LDAP Bind Mode
-  - name: SONAR_LDAP_USER_BASEDN
-    description: The Base DN under which SonarQube should search for user accounts in the LDAP directory
-    displayName: LDAP User Base DN
-  - name: SONAR_LDAP_USER_REAL_NAME_ATTR
-    description: The LDAP attribute which should be referenced to get a user's full name
-    displayName: LDAP Real Name Attribute
-  - name: SONAR_LDAP_USER_EMAIL_ATTR
-    description: The LDAP attribute which should be referenced to get a user's e-mail address
-    displayName: LDAP User E-Mail Attribute
-  - name: SONAR_LDAP_USER_REQUEST
-    description: An LDAP filter to be used to search for user objects in the LDAP directory
-    displayName: LDAP User Request Filter
-  - name: SONAR_LDAP_GROUP_BASEDN
-    description: The Base DN under which SonarQube should search for groups in the LDAP directory
-    displayName: LDAP Group Base DN
-  - name: SONAR_LDAP_GROUP_REQUEST
-    description: An LDAP filter to be used to search for group objects in the LDAP directory
-    displayName: LDAP Group Request Filter
-  - name: SONAR_LDAP_GROUP_ID_ATTR
-    description: The LDAP attribute which should be referenced to get a group's ID
-    displayName: LDAP Group Name Attribute
-  - name: SONAR_LDAP_CONTEXTFACTORY
-    description: The ContextFactory implementation to be used when communicating with the LDAP server
-    displayName: LDAP Context Factory
-    value: com.sun.jndi.ldap.LdapCtxFactory
   - name: JENKINS_URL
     description: The Jenkins URL used for the webhook
     displayName: Jenkins URL


### PR DESCRIPTION
This fixes an issue with the example template when using a namespace that isn't `sonarqube`. The rolebinding for the service account was set incorrectly causing an error getting the route for callback.

To test, run the example applier with a namespace not named 1`sonarqube`

```
ansible-playbook -i inventory/ apply.yml -e ci_cd_namespace=notsonarqube
```