### PR TITLE
Allow Sonar to start if plugin fails.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 .DS_Store
 target/
-example/apply.rety
+example/apply.retry
 example/roles
 example/sonar-auth-openshift-plugin-*.jar
 .project


### PR DESCRIPTION
Title says it all. If there is a failure to initialize the plugin (loading certs, getting callback, improper service account) then it will disable the plugin and allow Sonarqube to start. 

Improves error messaging when failure occurs.

Resolves #3 