### PR TITLE
Ability to customize route name, update build to 7.9.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,18 @@ kubernetes.service=https://${env:KUBERNETES_SERVICE_HOST}:${env:KUBERNETES_SERVI
 
 See the example set up using the [OpenShift Applier](https://github.com/redhat-cop/openshift-applier) [here](example/README.md)
 
+### Configuration Table
+
+| Config        | Purpose           |
+| ------------- |-------------|
+| sonar.auth.openshift.sar.groups      | A map converting OpenShift groups to Sonarqube roles |
+| sonar.auth.openshift.route.name      | The name of the route. Must also be defined in the service account (See example template)     |
+| oauth.cert | File system location of the certificate      |
+| ignore.certs | Option to ignore certificates. Not recommended for production      |
+| kubernetes.service | The url of the api server with port if necessary   |
+| sonar.auth.openshift.isEnabled | Ability to control whether to user this plugin   |
+| sonar.auth.openshift.button.color | The hex color of the login button (#666666)   |
+
 ### License
 
 Licensed under the [Apache License](http://www.apache.org/licenses/LICENSE-2.0.txt)

--- a/example/Dockerfile
+++ b/example/Dockerfile
@@ -10,7 +10,7 @@ RUN cp -a /opt/sonarqube/data /opt/sonarqube/data-init && \
 	chown root:root /opt/sonarqube && chmod -R gu+rwX /opt/sonarqube
 ADD plugins.sh /opt/sonarqube/bin/plugins.sh
 RUN /opt/sonarqube/bin/plugins.sh $sonar_plugins
-ADD https://github.com/rht-labs/sonar-auth-openshift/releases/latest/download/sonar-auth-openshift-plugin.jar  /opt/sonarqube/extensions-init/plugins/sonar-auth-openshift-plugin-1.1.0.jar
+ADD https://github.com/rht-labs/sonar-auth-openshift/releases/latest/download/sonar-auth-openshift-plugin.jar  /opt/sonarqube/extensions-init/plugins/
 RUN chown root:root /opt/sonarqube -R; \
     chmod 6775 /opt/sonarqube -R
 USER 1001

--- a/example/Dockerfile
+++ b/example/Dockerfile
@@ -10,7 +10,7 @@ RUN cp -a /opt/sonarqube/data /opt/sonarqube/data-init && \
 	chown root:root /opt/sonarqube && chmod -R gu+rwX /opt/sonarqube
 ADD plugins.sh /opt/sonarqube/bin/plugins.sh
 RUN /opt/sonarqube/bin/plugins.sh $sonar_plugins
-ADD sonar-auth-openshift-plugin-1.1.0.jar /opt/sonarqube/extensions-init/plugins/sonar-auth-openshift-plugin-1.1.0.jar
+ADD https://github.com/rht-labs/sonar-auth-openshift/releases/latest/download/sonar-auth-openshift-plugin.jar  /opt/sonarqube/extensions-init/plugins/sonar-auth-openshift-plugin-1.1.0.jar
 RUN chown root:root /opt/sonarqube -R; \
     chmod 6775 /opt/sonarqube -R
 USER 1001

--- a/example/inventory/group_vars/all.yml
+++ b/example/inventory/group_vars/all.yml
@@ -5,11 +5,11 @@ sonarqube_name: sonarqube
 sonarqube:
   build:
     NAME: "{{ sonarqube_name }}"
-    SOURCE_REPOSITORY_URL: "https://github.com/rht-labs/sonar-auth-openshift.git"
-    SOURCE_REPOSITORY_REF: "master"
+    SOURCE_REPOSITORY_URL: "https://github.com/mcanoy/sonar-auth-openshift.git"
+    SOURCE_REPOSITORY_REF: "sonar7.9.1"
     SOURCE_CONTEXT_DIR: example
     FROM_DOCKER_IMAGE: sonarqube
-    FROM_DOCKER_TAG: "7.7-community"
+    FROM_DOCKER_TAG: "7.9.1-community"
     FROM_DOCKER_IMAGE_REGISTRY_URL: "docker.io/sonarqube"
   postgresql:
     POSTGRESQL_DATABASE: sonar

--- a/example/inventory/group_vars/all.yml
+++ b/example/inventory/group_vars/all.yml
@@ -6,7 +6,7 @@ sonarqube:
   build:
     NAME: "{{ sonarqube_name }}"
     SOURCE_REPOSITORY_URL: "https://github.com/rht-labs/sonar-auth-openshift.git"
-    SOURCE_REPOSITORY_REF: "master""
+    SOURCE_REPOSITORY_REF: "master"
     SOURCE_CONTEXT_DIR: example
     FROM_DOCKER_IMAGE: sonarqube
     FROM_DOCKER_TAG: "7.9.1-community"

--- a/example/inventory/group_vars/all.yml
+++ b/example/inventory/group_vars/all.yml
@@ -5,8 +5,8 @@ sonarqube_name: sonarqube
 sonarqube:
   build:
     NAME: "{{ sonarqube_name }}"
-    SOURCE_REPOSITORY_URL: "https://github.com/mcanoy/sonar-auth-openshift.git"
-    SOURCE_REPOSITORY_REF: "sonar7.9.1"
+    SOURCE_REPOSITORY_URL: "https://github.com/rht-labs/sonar-auth-openshift.git"
+    SOURCE_REPOSITORY_REF: "master""
     SOURCE_CONTEXT_DIR: example
     FROM_DOCKER_IMAGE: sonarqube
     FROM_DOCKER_TAG: "7.9.1-community"

--- a/example/sonar.properties
+++ b/example/sonar.properties
@@ -16,3 +16,4 @@ sonar.auth.openshift.sar.groups=sonarqube_admin=sonar-administrators,sonarqube_u
 ignore.certs=false
 #oauth.cert=/opt/sonarqube/conf/oauth.crt
 sonar.search.javaAdditionalOpts=-Dnode.store.allow_mmapfs=false
+#sonar.auth.openshift.route.name=customname

--- a/example/sonar.properties
+++ b/example/sonar.properties
@@ -15,4 +15,4 @@ sonar.auth.openshift.button.color=#000000
 sonar.auth.openshift.sar.groups=sonarqube_admin=sonar-administrators,sonarqube_user=sonar-users
 ignore.certs=false
 #oauth.cert=/opt/sonarqube/conf/oauth.crt
-
+sonar.search.javaAdditionalOpts=-Dnode.store.allow_mmapfs=false

--- a/example/templates/sonarqube-deploy.yml
+++ b/example/templates/sonarqube-deploy.yml
@@ -7,7 +7,7 @@ objects:
   kind: ServiceAccount
   metadata:
     annotations:
-      serviceaccounts.openshift.io/oauth-redirectreference.sonarqube: '{"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"sonarqube"}}'
+      serviceaccounts.openshift.io/oauth-redirectreference.sonarqube: '{"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"${ROUTE_NAME}"}}'
     name: sonarqube
 - apiVersion: v1
   kind: RoleBinding
@@ -145,7 +145,7 @@ objects:
   metadata:
     labels:
       app: sonarqube
-    name: sonarqube
+    name: "${ROUTE_NAME}"
   spec:
     port:
       targetPort: 9000-tcp
@@ -183,10 +183,10 @@ parameters:
     displayName: SonarQube Storage Space Size
     required: true
     value: 5Gi
-  - name: SONAR_AUTH_REALM
-    value: ''
-    description: The type of authentication that SonarQube should be using (None or LDAP) (Ref - https://docs.sonarqube.org/display/PLUG/LDAP+Plugin)
-    displayName: SonarQube Authentication Realm
+  - name: ROUTE_NAME
+    value: sonarqube
+    description: The name of the route for sonarqube
+    displayName: SonarQube Route Name
   - name: SONAR_AUTOCREATE_USERS
     value: 'false'
     description: When using an external authentication system, should SonarQube automatically create accounts for users?

--- a/src/main/java/com/rhc/sonarqube/auth/openshift/OpenShiftConfiguration.java
+++ b/src/main/java/com/rhc/sonarqube/auth/openshift/OpenShiftConfiguration.java
@@ -38,6 +38,7 @@ public class OpenShiftConfiguration {
 	private static final String SUBCATEGORY = "Authentication";
 	
 	private static final String OPENSHIFT_GROUP_MAPPING = "sonar.auth.openshift.sar.groups";
+	private static final String ROUTE_NAME = "sonar.auth.openshift.route.name";
 	private static final String OAUTH_CERT = "oauth.cert";
 	private static final String IGNORE_CERTS = "ignore.certs";
 	private static final String WEB_URL = "sonar.auth.openshift.webUrl";
@@ -130,7 +131,7 @@ public class OpenShiftConfiguration {
 	}
 
 	public String getRouteURL(String namespace) {
-		return String.format(ROUTE_URI, getApiURL(), namespace, "sonarqube");
+		return String.format(ROUTE_URI, getApiURL(), namespace, config.get(ROUTE_NAME).orElse("sonarqube"));
 	}
 	
 	public static List<PropertyDefinition> definitions() {


### PR DESCRIPTION
Resolves #9 

When changing route name, the service account should also update its `oauth-redirectreference.sonarqube` property to match the route name as well as in the sonar.properties and, as in the example, the sonar deploy template.

To test get the PR code on your local machine and run the example. Attempt to login via OpenShift oauth. (see general readme instructions in the example for groups)