### PR TITLE
Add initial TravisCI Config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,63 @@
+language: java
+if: tag IS present OR NOT (branch == master)
+# before_cache:
+#   - export MAVEN_LOCAL_REPOSITORY=$(mvn -B help:evaluate -Dexpression=settings.localRepository -q -DforceStdout)
+# cache:
+#   directories:
+#     - $MAVEN_LOCAL_REPOSITORY
+install: mvn -q dependency:resolve
+jdk:
+  - openjdk8
+before_script:
+  - |
+    if [ "$TRAVIS_BRANCH" = "master" ] || [ "${TRAVIS_TAG}X" != "X" ]; then
+      git fetch --unshallow
+      mvn -q versions:set@remove-snapshot versions:commit@remove-snapshot -B;
+    fi
+script:
+  - |
+    mvn clean package -B
+    if [ "$TRAVIS_BRANCH" = "master" ] || [ "${TRAVIS_TAG}X" != "X" ]; then
+      ## Only run these commands when building a release
+      mvn sonar:sonar -Dsonar.login=${SONAR_PROJECT_TOKEN} -B
+      mvn -q dependency-check:check -B
+    fi
+before_deploy:
+  - export BUNDLE_JAR=$(ls target/*openshift*jar)
+  - echo "deploying $BUNDLE_JAR to GitHub releases"
+deploy:
+  provider: releases
+  api_key: "${GITHUB_OAUTH_TOKEN}"
+  file_glob: true
+  file:
+    - "${BUNDLE_JAR}"
+    - "target/site/jacoco/*"
+    - "target/dependency-check-report.html"
+  skip_cleanup: true
+  on:
+    tags: true
+after_success:
+  - |
+    if [ "$TRAVIS_BRANCH" = "master" ] || [ "${TRAVIS_TAG}X" != "X" ]; then
+      mvn -q versions:set@rev-to-next-snapshot versions:commit@rev-to-next-snapshot -B
+      git config --global user.name "Travis CI"
+      git config --global user.email "travis@travisci.org"
+      git checkout -b version-branch
+      git commit pom.xml -m 'Bumped micro version'
+      git checkout ${TRAVIS_BRANCH}
+      git merge version-branch -Xtheirs
+      git remote add pushorigin https://${GITHUB_OAUTH_TOKEN}@github.com/rht-labs/sonar-auth-openshift.git
+      git push pushorigin ${TRAVIS_BRANCH}
+    fi
+    if [ "$TRAVIS_BRANCH" = "Fix-after-success-stage" ] || [ "${TRAVIS_TAG}X" != "X" ]; then
+      mvn -q versions:set@rev-to-next-snapshot versions:commit@rev-to-next-snapshot -B
+      git config --global user.name "Travis CI"
+      git config --global user.email "travis@travisci.org"
+      git fetch --all
+      git checkout -b version-branch
+      git commit pom.xml -m 'Bumped micro version'
+      git checkout ${TRAVIS_BRANCH}
+      git merge version-branch -Xtheirs
+      git remote add pushorigin https://${GITHUB_OAUTH_TOKEN}@github.com/InfoSec812/sonar-auth-openshift.git
+      git push pushorigin Fix-after-success-stage
+    fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: java
 if: tag IS present OR NOT (branch == master)
+# It would be nice to use Travis' caching capabilities, but I have been unable to make it work successfully
 # before_cache:
 #   - export MAVEN_LOCAL_REPOSITORY=$(mvn -B help:evaluate -Dexpression=settings.localRepository -q -DforceStdout)
 # cache:
@@ -20,44 +21,19 @@ script:
     if [ "$TRAVIS_BRANCH" = "master" ] || [ "${TRAVIS_TAG}X" != "X" ]; then
       ## Only run these commands when building a release
       mvn sonar:sonar -Dsonar.login=${SONAR_PROJECT_TOKEN} -B
-      mvn -q dependency-check:check -B
+      # mvn -q dependency-check:check -B
     fi
 before_deploy:
-  - export BUNDLE_JAR=$(ls target/*openshift*jar)
-  - echo "deploying $BUNDLE_JAR to GitHub releases"
+  - export PLUGIN_JAR=$(ls target/sonar-auth-openshift-plugin*jar)
+  - echo "deploying $PLUGIN_JAR to GitHub releases"
 deploy:
   provider: releases
   api_key: "${GITHUB_OAUTH_TOKEN}"
   file_glob: true
   file:
-    - "${BUNDLE_JAR}"
-    - "target/site/jacoco/*"
-    - "target/dependency-check-report.html"
+    - "${PLUGIN_JAR}"
+#    - "target/site/jacoco/*"
+#    - "target/dependency-check-report.html"
   skip_cleanup: true
   on:
     tags: true
-after_success:
-  - |
-    if [ "$TRAVIS_BRANCH" = "master" ] || [ "${TRAVIS_TAG}X" != "X" ]; then
-      mvn -q versions:set@rev-to-next-snapshot versions:commit@rev-to-next-snapshot -B
-      git config --global user.name "Travis CI"
-      git config --global user.email "travis@travisci.org"
-      git checkout -b version-branch
-      git commit pom.xml -m 'Bumped micro version'
-      git checkout ${TRAVIS_BRANCH}
-      git merge version-branch -Xtheirs
-      git remote add pushorigin https://${GITHUB_OAUTH_TOKEN}@github.com/rht-labs/sonar-auth-openshift.git
-      git push pushorigin ${TRAVIS_BRANCH}
-    fi
-    if [ "$TRAVIS_BRANCH" = "Fix-after-success-stage" ] || [ "${TRAVIS_TAG}X" != "X" ]; then
-      mvn -q versions:set@rev-to-next-snapshot versions:commit@rev-to-next-snapshot -B
-      git config --global user.name "Travis CI"
-      git config --global user.email "travis@travisci.org"
-      git fetch --all
-      git checkout -b version-branch
-      git commit pom.xml -m 'Bumped micro version'
-      git checkout ${TRAVIS_BRANCH}
-      git merge version-branch -Xtheirs
-      git remote add pushorigin https://${GITHUB_OAUTH_TOKEN}@github.com/InfoSec812/sonar-auth-openshift.git
-      git push pushorigin Fix-after-success-stage
-    fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,9 @@ cache:
   - "$HOME/.m2"
 script:
   - |
-    mvn clean package -B
+    mvn clean compile -B -q
+    mvn test -B
+    mvn package -B -q
 
     # if [ "$TRAVIS_BRANCH" = "master" ] || [ "${TRAVIS_TAG}X" != "X" ]; then
       ## Only run these commands when building a release

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ cache:
   - "$HOME/.m2"
 script:
   - |
-    mvn clean package -q -B
+    mvn clean package -B
 
     # if [ "$TRAVIS_BRANCH" = "master" ] || [ "${TRAVIS_TAG}X" != "X" ]; then
       ## Only run these commands when building a release

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,28 +1,19 @@
 language: java
 if: tag IS present OR NOT (branch == master)
-# It would be nice to use Travis' caching capabilities, but I have been unable to make it work successfully
-# before_cache:
-#   - export MAVEN_LOCAL_REPOSITORY=$(mvn -B help:evaluate -Dexpression=settings.localRepository -q -DforceStdout)
-# cache:
-#   directories:
-#     - $MAVEN_LOCAL_REPOSITORY
-install: mvn -q dependency:resolve
 jdk:
   - openjdk8
-before_script:
-  - |
-    if [ "$TRAVIS_BRANCH" = "master" ] || [ "${TRAVIS_TAG}X" != "X" ]; then
-      git fetch --unshallow
-      mvn -q versions:set@remove-snapshot versions:commit@remove-snapshot -B;
-    fi
+cache:
+  directories:
+  - "$HOME/.m2"
 script:
   - |
-    mvn clean package -B
-    if [ "$TRAVIS_BRANCH" = "master" ] || [ "${TRAVIS_TAG}X" != "X" ]; then
+    mvn clean package -q -B
+
+    # if [ "$TRAVIS_BRANCH" = "master" ] || [ "${TRAVIS_TAG}X" != "X" ]; then
       ## Only run these commands when building a release
-      mvn sonar:sonar -Dsonar.login=${SONAR_PROJECT_TOKEN} -B
+      # mvn sonar:sonar -Dsonar.login=${SONAR_PROJECT_TOKEN} -B
       # mvn -q dependency-check:check -B
-    fi
+    # fi
 before_deploy:
   - export PLUGIN_JAR=$(ls target/sonar-auth-openshift-plugin*jar)
   - echo "deploying $PLUGIN_JAR to GitHub releases"
@@ -32,8 +23,8 @@ deploy:
   file_glob: true
   file:
     - "${PLUGIN_JAR}"
-#    - "target/site/jacoco/*"
-#    - "target/dependency-check-report.html"
+    #    - "target/site/jacoco/*"
+    #    - "target/dependency-check-report.html"
   skip_cleanup: true
   on:
     tags: true

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/rht-labs/sonar-auth-openshift.svg?branch=master)](https://travis-ci.org/rht-labs/sonar-auth-openshift)
+
 # Openshift Authentication Plugin for SonarQube 
 
 ## Description

--- a/pom.xml
+++ b/pom.xml
@@ -129,6 +129,7 @@
 	</dependencies>
 
 	<build>
+		<finalName>${project.artifactId}</finalName>
 		<plugins>
 			<plugin>
 				<groupId>org.sonarsource.sonar-packaging-maven-plugin</groupId>


### PR DESCRIPTION
Based off of @InfoSec812 's work, this is an initial Travis config which runs unit tests and builds the jar. If this is run against a tag created by a GitHub release, the jar will be automatically uploaded to the release as an artifact upon completion.

In the future, we might want to add analysis & SonarCloud.

In order to make the releases work, someone with appropriate permissions to release will need to add a GitHub personal access token to the `GITHUB_OAUTH_TOKEN` environment variable in Travis.

Part of issue #1 

cc: @mcanoy @InfoSec812 